### PR TITLE
fix: npm dev script throws error

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {},
   "scripts": {     
     "tsc": "tsc",
-    "dev": "ts-node-dev --respawn --transpileOnly ./app/app.ts",   
+    "dev": "ts-node-dev --respawn --transpile-only ./app/app.ts",   
     "prod": "tsc && node ./build/app.js"
   },
   "repository": {


### PR DESCRIPTION
Not sure when it changed, but the `--transpileOnly` flag throws
```
ts-node-dev: no script to run provided
Usage: ts-node-dev [options] script [arguments]
```

Changing the flag to `--transpile-only` works as intended.

Cheers!